### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "mysql": "^2.17.1",
     "node-cache": "^4.2.0",
     "nodemailer": "^6.2.1",
-    "npm": "^6.9.0",
     "passport": "^0.4.0",
     "passport-facebook": "^3.0.0",
     "passport-google-oauth20": "^2.0.0",


### PR DESCRIPTION

Hello nguyenhuutukhtn!

It seems like you have npm as one of your (dev-) dependency in ptudweb_thnews.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
